### PR TITLE
Add nette/boostrap dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 	],
 	"require": {
 		"php": "8.1 - 8.5",
+        "nette/bootstrap": "^3.2.5",
 		"nette/utils": "^4.0.6"
 	},
 	"suggest": {


### PR DESCRIPTION
- bug fix 
- BC break? no

Added "nette/bootstrap": "^3.2.5" dependency. 

With "nette/bootstrap" 3.2.4 and lower, error "Found section 'assets' in configuration, but correspodnig extension is missing." occurs when  `assets:` used in common.neon

